### PR TITLE
カテゴリーボタン修正

### DIFF
--- a/app/assets/javascripts/frema_index_header.js
+++ b/app/assets/javascripts/frema_index_header.js
@@ -5,21 +5,22 @@ $(function() {
     e.preventDefault(e);
     if ($('.parents_list .display-none').is(':visible')) {
       $('.parents_list .display-none').slideUp();
-      $('.children_list').slideUp();
-      $('.grand_children_list').slideUp();
+      // $('.children_list').slideUp();
+      // $('.grand_children_list').slideUp();
+      $(".child_category").remove();//一旦出ている子カテゴリ消します！
+      $(".grand_child_category").remove();//
     } else {
       $('.parents_list .display-none').slideDown();
     };
-  });
-  // if ($('#obj').is(':visible')) {
-  //   // 表示の場合
-  //   console.debug('表示');
-  // } else {
-  //   // 非表示の場合
-  //   console.debug('非表示');
-  // }
-  
+  }); 
 
+  // $('.parents_list').on('mouseout',function(){
+  //   $('.parents_list').slideUp();
+  // });
+
+  // $('.parents_list').on('mouseout',function(){
+  //   $('.parents_list').slideUp();
+  // });
 
   // $('.parents_list').on("hover",function(){
   //   $('.parents_list').slideUp();
@@ -39,6 +40,7 @@ $(function() {
 
   $(".parent_category").on("mouseover", function() {
     var id = this.id//どのリンクにマウスが乗ってるのか取得します
+    // console.log(id);
     $(".now-selected-red").removeClass("now-selected-red")//赤色のcssのためです
     $('#' + id).addClass("now-selected-red");//赤色のcssのためです
     $(".child_category").remove();//一旦出ている子カテゴリ消します！
@@ -50,8 +52,10 @@ $(function() {
       dataType: 'json'
     })
     .done(function(children) {
+      // console.log(children);
       children.forEach(function (child) {//帰ってきた子カテゴリー（配列）
         var html = buildChildHTML(child);//HTMLにして
+        console.log();
         $(".children_list").append(html);//リストに追加します
       })
     });


### PR DESCRIPTION
## What
カテゴリーボタン2回目に押した際に子供カテゴリーが表示されない問題の解決
## Why
ボタンでカテゴリーをクローズする処理を記述していましたが、その際の処理がslideUpこちらではクラスに対してdisplay:noneが付与されてしまうためその後htmlが追加変更されても表示されない。
対策としてremoveで一度消してしまう処理に変更しました。