### PR TITLE
商品購入確認画面カード情報

### DIFF
--- a/app/controllers/item/secound_controller.rb
+++ b/app/controllers/item/secound_controller.rb
@@ -8,6 +8,16 @@ before_action :configure_sign_up_params, only: [:create]
 
   def show
     @item = Item.find(params[:id])
+
+    # pay.jpのカード参照用記述
+    @card = Card.where(user_id: current_user.id).first
+    if @card.blank?
+    #   redirect_to new_card_path
+    else
+      Payjp.api_key = Rails.application.secrets.payjp_private_key
+      customer = Payjp::Customer.retrieve(@card.customer_id)
+      @default_card_information = customer.cards.retrieve(@card.card_id)
+    end
   end
 
   def bought

--- a/app/views/item/secound/show.html.haml
+++ b/app/views/item/secound/show.html.haml
@@ -42,8 +42,19 @@
             .buypage__main__item__form__pay-way__logo
               = image_tag "card/visa.svg", alt: "カードロゴ画像", class: "",size: "49x15"
           .right
-            = link_to '変更する', '/', class: 'text-decolation-none'
-            
+            .div
+              = link_to '変更する', '/', class: 'text-decolation-none'
+            %br
+            - if @card.blank?
+              .div
+                カード未登録
+            - else
+              .div
+                = "**** **** **** " + @default_card_information.last4
+              .div
+                - exp_month = @default_card_information.exp_month.to_s
+                - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                = exp_month + " / " + exp_year
               
                 
         .buypage__main__item__form__delivery


### PR DESCRIPTION
## What
商品購入確認画面でカード情報が参照されていなかったので登録済みの場合はカード番号表示、未登録の場合は未登録と表示するように変更しました。
## Why
https://gyazo.com/daa8288a9833f5f43631f282bad9d5dc