### PR TITLE
他人の商品編集ページ不可

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -42,6 +42,11 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    if @item.seller_id == current_user.id
+      
+    else
+      redirect_to root_path
+    end
   end
 
   def update


### PR DESCRIPTION
他人の商品編集ページには出品者IDが異なる場合にはアクセスできずrootにリダイレクトさせる。